### PR TITLE
fix building without `framework`-feature

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -190,72 +190,72 @@ pub(crate) fn dispatch<'rec>(
     cache_and_http: Arc<CacheAndHttp>,
 ) -> BoxFuture<'rec, ()> {
     async move {
-    match (event_handler, raw_event_handler) {
-        (None, None) => {}, // Do nothing
-        (Some(ref h), None) => {
-            match event {
-                DispatchEvent::Model(Event::MessageCreate(mut event)) => {
-                    update(&cache_and_http, &mut event).await;
+        match (event_handler, raw_event_handler) {
+            (None, None) => {}, // Do nothing
+            (Some(ref h), None) => {
+                match event {
+                    DispatchEvent::Model(Event::MessageCreate(mut event)) => {
+                        update(&cache_and_http, &mut event).await;
 
-                    #[cfg(not(feature = "cache"))]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-                    #[cfg(feature = "cache")]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.http, &cache_and_http.cache);
+                        #[cfg(not(feature = "cache"))]
+                        let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                        #[cfg(feature = "cache")]
+                        let context = context(data, runner_tx, shard_id, &cache_and_http.http, &cache_and_http.cache);
 
-                    dispatch_message(
-                        context.clone(),
-                        event.message.clone(),
-                        h,
-                    ).await;
-                },
-                other => {
-                    handle_event(
-                        other,
-                        data,
-                        h,
-                        runner_tx,
-                        shard_id,
-                        cache_and_http,
-                    ).await;
+                        dispatch_message(
+                            context.clone(),
+                            event.message.clone(),
+                            h,
+                        ).await;
+                    },
+                    other => {
+                        handle_event(
+                            other,
+                            data,
+                            h,
+                            runner_tx,
+                            shard_id,
+                            cache_and_http,
+                        ).await;
+                    }
                 }
-            }
-        },
-        (None, Some(ref rh)) => {
-            match event {
-                DispatchEvent::Model(e) => {
-                    #[cfg(not(feature = "cache"))]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.http);
-                    #[cfg(feature = "cache")]
-                    let context = context(data, runner_tx, shard_id, &cache_and_http.http, &cache_and_http.cache);
+            },
+            (None, Some(ref rh)) => {
+                match event {
+                    DispatchEvent::Model(e) => {
+                        #[cfg(not(feature = "cache"))]
+                        let context = context(data, runner_tx, shard_id, &cache_and_http.http);
+                        #[cfg(feature = "cache")]
+                        let context = context(data, runner_tx, shard_id, &cache_and_http.http, &cache_and_http.cache);
 
-                    let event_handler = Arc::clone(rh);
+                        let event_handler = Arc::clone(rh);
 
-                    tokio::spawn(async move {
-                        event_handler.raw_event(context, e).await;
-                    });
-                },
-                _ => {}
+                        tokio::spawn(async move {
+                            event_handler.raw_event(context, e).await;
+                        });
+                    },
+                    _ => {}
+                }
+            },
+            (Some(ref h), Some(ref rh)) => {
+                if let DispatchEvent::Model(ref e) = event {
+                        dispatch(DispatchEvent::Model(e.clone()),
+                                 data,
+                                 &None,
+                                 raw_event_handler,
+                                 runner_tx,
+                                 shard_id,
+                                 Arc::clone(&cache_and_http)).await;
+                }
+                dispatch(event,
+                         data,
+                         event_handler,
+                         &None,
+                         runner_tx,
+                         shard_id,
+                         cache_and_http).await;
             }
-        },
-        (Some(ref h), Some(ref rh)) => {
-            if let DispatchEvent::Model(ref e) = event {
-                    dispatch(DispatchEvent::Model(e.clone()),
-                             data,
-                             &None,
-                             raw_event_handler,
-                             runner_tx,
-                             shard_id,
-                             Arc::clone(&cache_and_http)).await;
-            }
-            dispatch(event,
-                     data,
-                     event_handler,
-                     &None,
-                     runner_tx,
-                     shard_id,
-                     cache_and_http).await;
-        }
-    };
+        };
     }.boxed()
 }
 

--- a/src/client/extras.rs
+++ b/src/client/extras.rs
@@ -77,6 +77,7 @@ impl Default for Extras {
         Extras {
             event_handler: None,
             raw_event_handler: None,
+            #[cfg(feature = "framework")]
             framework: Arc::new(None),
             #[cfg(feature = "cache")]
             timeout: None,


### PR DESCRIPTION
This PR allows us to build serenity-await without framework-feature.

This PR contains a lot of indentation changes so you can see 64ce5dfbff9b1e1ecc37c6edb28ef30349417e44 and know what the difference is. Or you can use the "Hide whitespace changes" option to review this PR.

<img src="https://user-images.githubusercontent.com/45287/77227320-da637500-6bc2-11ea-9f59-8fbd6a2c1361.png" width=320 />

I checked this PR by building `01_basic_ping_bot` project with following setting:

```
default-features = false
features = ["rustls_backend", "gateway", "model", "http", "client"]
```