### PR TITLE
fix dispatch function

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -168,11 +168,11 @@ pub(crate) fn dispatch<'rec>(
                 dispatch(event,
                     framework,
                     data,
+                    event_handler,
                     &None,
-                    raw_event_handler,
                     runner_tx,
                     shard_id,
-                    Arc::clone(&cache_and_http))
+                    cache_and_http)
                 .await;
             }
         };


### PR DESCRIPTION
I found that the dispatch function was broken by 7a8feb734103d612c03b1a31fc55e66d7650c02a.

If we set both `event_handler` and `raw_event_handler` , `event_handler` receives no events (Instead of that, `raw_event_handler` receives all events twice ) . To reproduce it, I patched `01_basic_ping_bot` as follows:

```diff
diff --git a/examples/01_basic_ping_bot/src/main.rs b/examples/01_basic_ping_bot/src/main.rs
index b4bd3b52..b12faa5f 100644
--- a/examples/01_basic_ping_bot/src/main.rs
+++ b/examples/01_basic_ping_bot/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serenity::{
     async_trait,
-    model::{channel::Message, gateway::Ready},
+    model::{channel::Message, gateway::Ready, prelude::Event},
     prelude::*,
 };
 
@@ -38,6 +38,15 @@ impl EventHandler for Handler {
     }
 }
 
+struct RawHandler;
+
+#[async_trait]
+impl RawEventHandler for RawHandler {
+    async fn raw_event(&self, _ctx: Context, ev: Event) {
+        println!("{:?} received", ev);
+    }
+}
+
 #[tokio::main]
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
@@ -47,7 +56,9 @@ async fn main() {
     // Create a new instance of the Client, logging in as a bot. This will
     // automatically prepend your bot token with "Bot ", which is a requirement
     // by Discord for bot users.
-    let mut client = Client::new(&token, Handler)
+    let mut client = Client::new_with_extras(&token, |e| {
+        e.event_handler(Handler).raw_event_handler(RawHandler)
+    })
         .await
         .expect("Err creating client");
 ```